### PR TITLE
Add a MinimalDjangoError, for cases when you don't have a request.

### DIFF
--- a/django_keyerror/error.py
+++ b/django_keyerror/error.py
@@ -96,6 +96,17 @@ class DjangoError(Error):
 
         return {}
 
+class MinimalDjangoError(Error):
+    """
+    Like DjangoError, except doesn't require a request.
+    """
+    def __init__(self, *args, **kwargs):
+        super(MinimalDjangoError, self).__init__(*args, **kwargs)
+
+        self.update({
+            'type': 'django',
+        })
+
 class QueueError(Error):
     def __init__(self, *args, **kwargs):
         super(QueueError, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Not much more to this than the PR title.

The motivation for this PR was an internal patch to Django, to send Exceptions which occur while rendering an included template to KeyError (instead of just logging them), i.e. modifying https://github.com/django/django/blob/master/django/template/loader_tags.py#L213-L230 . Accessing the `request` instance at that time isn't possible. I suppose you could find the request via `sys._getframe` hacks, but this feels cleaner.