### PR TITLE
Don't require an explicit 'ident'.

### DIFF
--- a/django_keyerror/error.py
+++ b/django_keyerror/error.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class Error(dict):
-    def __init__(self, exc_type, exc_value, exc_traceback, ident):
+    def __init__(self, exc_type, exc_value, exc_traceback, ident=None):
         tb = traceback.extract_tb(exc_traceback)
         synopsis = traceback.format_exception_only(exc_type, exc_value)[-1]
 


### PR DESCRIPTION
This fixes Django Lightyweight Queue error reporting, as the `QueueError` class in instantiated via `QueueError(*exc_info).send()`. As there's no `ident` specified, that instantiation errors.