### PR TITLE
Support Python 3

### DIFF
--- a/django_keyerror/error.py
+++ b/django_keyerror/error.py
@@ -1,10 +1,10 @@
 import sys
 import json
-import urllib
 import socket
 import logging
-import urllib2
 import traceback
+
+from six.moves import urllib
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -38,12 +38,12 @@ class Error(dict):
 
     def _send(self, url, data, headers):
         encoded_data = utils.unicode_encode_dict(data)
-        req = urllib2.Request(url, urllib.urlencode(encoded_data), headers)
+        req = urllib.request.Request(url, urllib.parse.urlencode(encoded_data), headers)
 
         try:
             if not app_settings.IS_TEST:
-                urllib2.urlopen(req, timeout=app_settings.TIMEOUT)  # pragma: no cover
-        except urllib2.HTTPError as e:
+                urllib.request.urlopen(req, timeout=app_settings.TIMEOUT) # pragma: no cover
+        except urllib.error.HTTPError as e:
             try:
                 # We try and print a descriptive message on the first line of
                 # the response

--- a/django_keyerror/error.py
+++ b/django_keyerror/error.py
@@ -24,7 +24,7 @@ class Error(dict):
             'ident': ident or '',
             'server': socket.gethostname()[:100],
             'synopsis': synopsis.strip()[:200],
-            'traceback': json.dumps(tb),
+            'traceback': json.dumps([list(x) for x in tb]),
 
             'apps': json.dumps(settings.INSTALLED_APPS),
             'exc_type': exc_type.__name__,

--- a/django_keyerror/error.py
+++ b/django_keyerror/error.py
@@ -38,7 +38,7 @@ class Error(dict):
 
     def _send(self, url, data, headers):
         encoded_data = utils.unicode_encode_dict(data)
-        req = urllib.request.Request(url, urllib.parse.urlencode(encoded_data), headers)
+        req = urllib.request.Request(url, urllib.parse.urlencode(encoded_data).encode('ascii'), headers)
 
         try:
             if not app_settings.IS_TEST:

--- a/django_keyerror/management/commands/keyerror_deployment_notification.py
+++ b/django_keyerror/management/commands/keyerror_deployment_notification.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         req = urllib.request.Request(post_url, urllib.parse.urlencode({
             'url': options['url'],
             'title': options['title'],
-        }), {
+        }).encode('ascii'), {
             'X-API-Key': app_settings.SECRET_KEY,
         })
 

--- a/django_keyerror/management/commands/keyerror_deployment_notification.py
+++ b/django_keyerror/management/commands/keyerror_deployment_notification.py
@@ -1,5 +1,4 @@
-import urllib
-import urllib2
+from six.moves import urllib
 
 from django.core.management.base import BaseCommand, CommandError
 
@@ -18,7 +17,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         post_url = app_settings.URL % '/deployments'
 
-        req = urllib2.Request(post_url, urllib.urlencode({
+        req = urllib.request.Request(post_url, urllib.parse.urlencode({
             'url': options['url'],
             'title': options['title'],
         }), {
@@ -29,6 +28,6 @@ class Command(BaseCommand):
             raise CommandError("KeyError is not enabled; exiting.")
 
         try: # pragma: no cover
-            urllib2.urlopen(req, timeout=5)
-        except urllib2.HTTPError, exc: # pragma: no cover
+            urllib.request.urlopen(req, timeout=5)
+        except urllib.error.HTTPError as exc: # pragma: no cover
             raise CommandError("Error when notifying KeyError: %s" % exc)

--- a/django_keyerror/utils.py
+++ b/django_keyerror/utils.py
@@ -21,7 +21,7 @@ def format_datagram(type_, fmt='', *args, **kwargs):
     fmt = '!2sH20s%s' % fmt
 
     args = [
-        'KE',
+        b'KE',
         type_,
         binascii.unhexlify(app_settings.SECRET_KEY),
     ] + list(args)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import six
 import sys
 import mock
 
@@ -99,9 +100,13 @@ class SmokeTest(TestCase):
 
         self.assertEqual(url, 'http://api.keyerror.com/v1/errors')
 
+        message = "ZeroDivisionError: integer division or modulo by zero"
+        if six.PY3:
+            message = "ZeroDivisionError: division by zero"
+
         self.assertEqual(
             data['synopsis'],
-            "ZeroDivisionError: integer division or modulo by zero",
+            message,
         )
         self.assertEqual(data['url'], 'http://testserver/error')
         self.assertEqual(data['user'], '{}')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -61,7 +61,7 @@ class SmokeTest(TestCase):
         utils.ping()
 
         mock_send_datagram.assert_called_once_with(
-            'KE\x00\x00\xd4\xba\xccN\xfcZl\n\xc3\x89\xcc\xa5WN\xa7\xec~\x84\x18\xdc',
+            b'KE\x00\x00\xd4\xba\xccN\xfcZl\n\xc3\x89\xcc\xa5WN\xa7\xec~\x84\x18\xdc',
         )
 
     @mock.patch('django_keyerror.utils.send_datagram')
@@ -69,9 +69,9 @@ class SmokeTest(TestCase):
         utils.report_response("https://example.org/", 'path.to.view', 100)
 
         mock_send_datagram.assert_called_once_with(
-            'KE\x00\x01\xd4\xba\xccN\xfcZl\n\xc3\x89\xcc\xa5WN\xa7'
-            '\xec~\x84\x18\xdc\x00\x00\x00d\x00\x14'
-            'https://example.org/\x00\x0cpath.to.view'
+            b'KE\x00\x01\xd4\xba\xccN\xfcZl\n\xc3\x89\xcc\xa5WN\xa7'
+            b'\xec~\x84\x18\xdc\x00\x00\x00d\x00\x14'
+            b'https://example.org/\x00\x0cpath.to.view'
         )
 
     def test_success(self):


### PR DESCRIPTION
Switches to using `six` for the urllib handling (credit to @prophile for most of these) and explicitly uses bytes (rather than strings) where this is needed for network requests & datagrams.