### PR TITLE
Support Python 3 causal tracebacks

### DIFF
--- a/django_keyerror/error.py
+++ b/django_keyerror/error.py
@@ -20,6 +20,10 @@ class Error(dict):
         tb = traceback.extract_tb(exc_traceback)
         synopsis = traceback.format_exception_only(exc_type, exc_value)[-1]
 
+        cause = getattr(exc_value, '__cause__', None)
+        if cause is not None:
+            tb += traceback.extract_tb(cause.__traceback__)
+
         self.update({
             'ident': ident or '',
             'server': socket.gethostname()[:100],

--- a/tests/python_3_tests.py
+++ b/tests/python_3_tests.py
@@ -1,0 +1,104 @@
+import sys
+import json
+import mock
+
+from django.test import TestCase
+from django_keyerror.error import Error
+
+
+class Python3Test(TestCase):
+    @mock.patch('django_keyerror.error.Error._send')
+    def test_traceback_with_context(self, mock_send):
+        def inner():
+            raise ValueError('inner')
+
+        def outer():
+            try:
+                inner()
+            except ValueError as e:
+                raise TypeError('outer')
+
+        try:
+            outer()
+        except Exception:
+            Error(*sys.exc_info()).send()
+
+        self.assertEqual(mock_send.call_count, 1)
+        _, data, _ = mock_send.call_args[0]
+        traceback = json.loads(data['traceback'])
+
+        self.assertNotIn(
+            [mock.ANY, mock.ANY, 'inner', mock.ANY],
+            traceback,
+            "Traceback should not contain inner function",
+        )
+
+        self.assertIn(
+            [mock.ANY, mock.ANY, 'outer', mock.ANY],
+            traceback,
+            "Traceback should contain outer function",
+        )
+
+    @mock.patch('django_keyerror.error.Error._send')
+    def test_traceback_with_cause(self, mock_send):
+        def inner():
+            raise ValueError('inner')
+
+        def outer():
+            try:
+                inner()
+            except ValueError as e:
+                raise TypeError('outer') from e
+
+        try:
+            outer()
+        except Exception:
+            Error(*sys.exc_info()).send()
+
+        self.assertEqual(mock_send.call_count, 1)
+        _, data, _ = mock_send.call_args[0]
+        traceback = json.loads(data['traceback'])
+
+        self.assertIn(
+            [mock.ANY, mock.ANY, 'inner', mock.ANY],
+            traceback,
+            "Traceback should contain inner function",
+        )
+
+        self.assertIn(
+            [mock.ANY, mock.ANY, 'outer', mock.ANY],
+            traceback,
+            "Traceback should contain outer function",
+        )
+
+    @mock.patch('django_keyerror.error.Error._send')
+    def test_traceback_with_explicit_none_cause(self, mock_send):
+        def inner():
+            raise ValueError('inner')
+
+        def outer():
+            try:
+                inner()
+            except ValueError as e:
+                raise TypeError('outer') from None
+
+        try:
+            outer()
+        except Exception:
+            Error(*sys.exc_info()).send()
+
+        self.assertEqual(mock_send.call_count, 1)
+        _, data, _ = mock_send.call_args[0]
+        traceback = json.loads(data['traceback'])
+
+        self.assertNotIn(
+            [mock.ANY, mock.ANY, 'inner', mock.ANY],
+            traceback,
+            "Traceback should not contain inner function",
+        )
+
+        self.assertIn(
+            [mock.ANY, mock.ANY, 'outer', mock.ANY],
+            traceback,
+            "Traceback should contain outer function",
+        )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -17,7 +17,7 @@ from django_keyerror.api import group_errors
 from django_keyerror.app_settings import app_settings
 
 
-if sys.version_info >= (3, 0, 0):
+if six.PY3:
     from .python_3_tests import Python3Test
 
 


### PR DESCRIPTION
This means that tracebacks will now include the causal traceback for exceptions raised by `raise MyException from e` syntax.

This adds a test to show that Python 3 context tracebacks are unaffected, though we might want to change that and support them at some point.